### PR TITLE
CA issuer

### DIFF
--- a/cert-manager/ca-issuer.yaml
+++ b/cert-manager/ca-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: ca-key-pair

--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -9,6 +9,12 @@ resources:
 # see: https://cert-manager.io/docs/configuration/acme/#configuration
 # and uncomment the following line
 # - letsencrypt-cluster-issuer.yaml
+# If you would like to setup your own CA cluster issuer, generate a new key pair or use an
+# existing one. Save the keys as a secret according to
+# https://docs.cert-manager.io/en/release-0.11/tasks/issuers/setup-ca.html. Change
+# the issuerRef name in kubeflow/common/istio/ingress-certificate.yaml to
+# "ca-issuer" and uncomment the following line@ 
+# - ca-issuer.yaml
 
 images:
 - name: quay.io/jetstack/cert-manager-controller

--- a/kubeflow/common/istio/ingress-certificate.yaml
+++ b/kubeflow/common/istio/ingress-certificate.yaml
@@ -5,8 +5,11 @@ metadata:
   namespace: istio-system
 spec:
   secretName: istio-ingressgateway-certs
+  # change the issuerRef name to ca-issuer if you want
+  # to use cert-manager with your own CA key pair
   issuerRef:
     name: kubeflow-self-signing-issuer
+    # name: ca-issuer
     kind: ClusterIssuer
   commonName: kubeflow.example.com
   dnsNames:


### PR DESCRIPTION
I had some problems with the self-signed certs and created a config for a CA issuer as an alternative to the self-signed-issuer for situations where letsencrypt is not an option.